### PR TITLE
Añadir informes de ventas de productos con vistas detalladas en PDF y…

### DIFF
--- a/Apps/reports/urls.py
+++ b/Apps/reports/urls.py
@@ -5,8 +5,13 @@ urlpatterns = [
 
     path('ventas-generales/', views.menu_reportes, name='menu_reportes'),
     path('reportes-generales/', views.reports_general, name='reports_general'),
+    path('reportes-productos/', views.reports_productos, name='reports_productos'),
 
     # API (JSON + descargas)
     path('api/ventas/datos/', views.api_ventas_datos, name='api_ventas_datos'),
     path('api/ventas/descargar/', views.api_ventas_descargar, name='api_ventas_descargar'),
+
+    # API productos
+    path('api/ventas-productos/datos/', views.api_ventas_productos_datos, name='api_ventas_productos_datos'),
+    path('api/ventas-productos/descargar/', views.api_ventas_productos_descargar, name='api_ventas_productos_descargar'),
 ]

--- a/Apps/reports/views.py
+++ b/Apps/reports/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
 from django.http import JsonResponse, HttpResponse
-from django.db.models import Sum
+from django.db.models import Sum, F, DecimalField, ExpressionWrapper
+from django.db.models.functions import Coalesce
 from django.db.models.functions import TruncDate, TruncWeek, TruncMonth, TruncYear
 from django.contrib.auth.decorators import login_required
 from django.utils import timezone
@@ -32,6 +33,12 @@ def menu_reportes(request):
 def reports_general(request):
     """Vista de reportes generales"""
     return render(request, 'reports/reports_general.html')
+
+
+@login_required
+def reports_productos(request):
+    """Vista de reporte de ventas por productos"""
+    return render(request, 'reports/reports_productos.html')
 
 
 EXCLUDED_STATUSES = (
@@ -205,6 +212,94 @@ def _get_invoice_detail_rows(inicio: date, fin: date):
             })
 
     return rows
+
+
+def _aggregate_product_sales(inicio: date, fin: date):
+    """Agrega ventas por producto en el rango dado.
+
+    Retorna lista de dicts: {item_id, nombre, cantidad, total} ordenado por total desc.
+    """
+    start_dt, end_dt_excl = _date_range_to_datetimes(inicio, fin)
+
+    line_total = ExpressionWrapper(
+        F('quantity') * F('price'),
+        output_field=DecimalField(max_digits=12, decimal_places=2),
+    )
+
+    rows = (
+        InvoiceItem.objects
+        .filter(invoice__date__gte=start_dt, invoice__date__lt=end_dt_excl)
+        .exclude(invoice__status__in=EXCLUDED_STATUSES)
+        .values('item_id', 'item__Name')
+        .annotate(
+            cantidad=Coalesce(Sum('quantity'), 0),
+            total=Coalesce(Sum(line_total), Decimal('0.00')),
+        )
+        .order_by('-total', 'item__Name')
+    )
+
+    out = []
+    for r in rows:
+        out.append({
+            'item_id': r['item_id'],
+            'nombre': r.get('item__Name') or f"Producto #{r['item_id']}",
+            'cantidad': int(r['cantidad'] or 0),
+            'total': r['total'] or Decimal('0.00'),
+        })
+    return out
+
+
+def _build_products_payload(fecha_inicio: date, fecha_fin: date, top_n: int = 15):
+    days_len = (fecha_fin - fecha_inicio).days + 1
+    prev_fin = fecha_inicio - timedelta(days=1)
+    prev_inicio = prev_fin - timedelta(days=days_len - 1)
+
+    actual_rows = _aggregate_product_sales(fecha_inicio, fecha_fin)
+    anterior_rows = _aggregate_product_sales(prev_inicio, prev_fin)
+
+    anterior_by_id = {r['item_id']: r for r in anterior_rows}
+
+    top_rows = actual_rows[:max(1, int(top_n))]
+    labels = [r['nombre'] for r in top_rows]
+    valores_actual = [float(r['total']) for r in top_rows]
+    valores_anterior = [float((anterior_by_id.get(r['item_id']) or {}).get('total', Decimal('0.00'))) for r in top_rows]
+
+    total_actual = sum(float(r['total']) for r in actual_rows)
+    total_anterior = sum(float(r['total']) for r in anterior_rows)
+    diferencia = total_actual - total_anterior
+    if total_anterior == 0:
+        porcentaje = 0.0 if total_actual == 0 else 100.0
+    else:
+        porcentaje = (diferencia / total_anterior) * 100.0
+
+    return {
+        'labels': labels,
+        'datasets': [
+            {
+                'label': 'Período Actual',
+                'data': valores_actual,
+                'borderColor': '#10b981',
+                'backgroundColor': 'rgba(16, 185, 129, 0.35)',
+            },
+            {
+                'label': 'Período Anterior',
+                'data': valores_anterior,
+                'borderColor': '#6b7280',
+                'backgroundColor': 'rgba(107, 114, 128, 0.25)',
+            },
+        ],
+        'totales': {
+            'actual': total_actual,
+            'anterior': total_anterior,
+            'diferencia': diferencia,
+            'porcentaje_cambio': porcentaje,
+        },
+        'meta': {
+            'prev_inicio': prev_inicio.isoformat(),
+            'prev_fin': prev_fin.isoformat(),
+            'top_n': int(top_n),
+        },
+    }
 
 
 def _render_pdf_with_puppeteer(template_src: str, context: dict, filename: str):
@@ -415,6 +510,104 @@ def api_ventas_descargar(request):
 
             return _render_pdf_with_puppeteer(
                 'reports/reporte_pdf_ventas.html',
+                context,
+                filename=f"{filename_base}.pdf",
+            )
+
+        return JsonResponse({'error': 'Formato inválido. Usa pdf o excel.'}, status=400)
+    except ValueError as e:
+        return JsonResponse({'error': str(e)}, status=400)
+    except Exception:
+        return JsonResponse({'error': 'Ocurrió un error generando la descarga.'}, status=500)
+
+
+@login_required
+def api_ventas_productos_datos(request):
+    try:
+        fecha_inicio = _parse_iso_date(request.GET.get('fecha_inicio', ''))
+        fecha_fin = _parse_iso_date(request.GET.get('fecha_fin', ''))
+        top_n = int(request.GET.get('top', '15') or 15)
+
+        payload = _build_products_payload(fecha_inicio, fecha_fin, top_n=top_n)
+        return JsonResponse(payload)
+    except ValueError as e:
+        return JsonResponse({'error': str(e)}, status=400)
+    except Exception:
+        return JsonResponse({'error': 'Ocurrió un error generando el reporte.'}, status=500)
+
+
+@login_required
+def api_ventas_productos_descargar(request):
+    try:
+        fecha_inicio = _parse_iso_date(request.GET.get('fecha_inicio', ''))
+        fecha_fin = _parse_iso_date(request.GET.get('fecha_fin', ''))
+        formato = request.GET.get('formato', 'excel')
+
+        filename_base = f"ventas_productos_{fecha_inicio.isoformat()}_{fecha_fin.isoformat()}"
+        rows = _aggregate_product_sales(fecha_inicio, fecha_fin)
+
+        if formato in ('excel', 'csv'):
+            response = HttpResponse(content_type='text/csv; charset=utf-8')
+            response['Content-Disposition'] = f'attachment; filename="{filename_base}.csv"'
+            response.write('\ufeff')
+            writer = csv.writer(response)
+            writer.writerow(['Producto', 'Cantidad', 'Total'])
+            for r in rows:
+                writer.writerow([r['nombre'], r['cantidad'], f"{float(r['total']):.2f}"])
+            return response
+
+        if formato == 'pdf':
+            total_general = sum(float(r['total']) for r in rows)
+
+            top_revenue_raw = rows[:5]
+            max_rev = max((float(r['total']) for r in top_revenue_raw), default=0.0) or 1.0
+            top_revenue = []
+            for r in top_revenue_raw:
+                top_revenue.append({
+                    'nombre': r['nombre'],
+                    'total': r['total'],
+                    'pct': (float(r['total']) / max_rev) * 100.0,
+                })
+
+            top_qty_sorted = sorted(rows, key=lambda x: int(x.get('cantidad') or 0), reverse=True)[:5]
+            max_qty = max((int(r.get('cantidad') or 0) for r in top_qty_sorted), default=0) or 1
+            top_qty = []
+            for r in top_qty_sorted:
+                qty = int(r.get('cantidad') or 0)
+                top_qty.append({
+                    'nombre': r['nombre'],
+                    'cantidad': qty,
+                    'pct': (qty / max_qty) * 100.0,
+                })
+
+            top_n = 5
+            top_total = sum(float(r['total']) for r in rows[:top_n])
+            otros_total = max(0.0, total_general - top_total)
+            if total_general <= 0:
+                top_pct = 0.0
+                otros_pct = 0.0
+            else:
+                top_pct = (top_total / total_general) * 100.0
+                otros_pct = 100.0 - top_pct
+
+            context = {
+                'fecha_inicio': fecha_inicio,
+                'fecha_fin': fecha_fin,
+                'rows': rows,
+                'total_general': total_general,
+                'top_revenue': top_revenue,
+                'top_qty': top_qty,
+                'dist': {
+                    'top_n': top_n,
+                    'top_total': top_total,
+                    'otros_total': otros_total,
+                    'top_pct': top_pct,
+                    'otros_pct': otros_pct,
+                },
+            }
+
+            return _render_pdf_with_puppeteer(
+                'reports/reporte_pdf_producto_ventas.html',
                 context,
                 filename=f"{filename_base}.pdf",
             )

--- a/templates/reports/menu_reports.html
+++ b/templates/reports/menu_reports.html
@@ -262,7 +262,7 @@
         </div>
 
         <!-- Ventas por ítem -->
-        <div class="reporte-card" onclick="window.location.href='#'">
+        <div class="reporte-card" onclick="window.location.href='{% url 'reports_productos' %}'">
             <div class="card-header">
                 <div class="icon-container icon-money">💵</div>
                 <span class="star-icon active" onclick="event.stopPropagation(); toggleStar(this)">★</span>

--- a/templates/reports/reporte_pdf_producto_ventas.html
+++ b/templates/reports/reporte_pdf_producto_ventas.html
@@ -1,0 +1,363 @@
+{% load humanize %}
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Reporte Ventas por Productos</title>
+  <style>
+    :root {
+      --text: #111827;
+      --muted: #6b7280;
+      --line: #e5e7eb;
+      --bg: #ffffff;
+      --chip: #f3f4f6;
+      --accent: #10b981;
+      --accent-2: #2563eb;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      padding: 24px;
+      font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
+      color: var(--text);
+      background: #f9fafb;
+    }
+
+    .page {
+      max-width: 210mm;
+      margin: 0 auto;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      padding: 22px;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 16px;
+      padding-bottom: 14px;
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 14px;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+    }
+
+    .brand img {
+      height: 56px;
+      width: auto;
+      object-fit: contain;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 20px;
+      font-weight: 800;
+      letter-spacing: 0.2px;
+    }
+
+    .meta {
+      margin-top: 6px;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.4;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 6px 10px;
+      border-radius: 999px;
+      background: var(--chip);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      margin-top: 10px;
+      margin-bottom: 14px;
+    }
+
+    .card {
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 12px 14px;
+      background: #ffffff;
+    }
+
+    .card-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 10px;
+    }
+
+    .card-title h2 {
+      margin: 0;
+      font-size: 12px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      font-weight: 800;
+    }
+
+    .chip {
+      display: inline-block;
+      padding: 4px 8px;
+      border-radius: 999px;
+      background: #ecfdf5;
+      color: #065f46;
+      font-weight: 800;
+      font-size: 11px;
+      white-space: nowrap;
+    }
+
+    .rows {
+      display: grid;
+      gap: 8px;
+    }
+
+    .row {
+      display: grid;
+      grid-template-columns: 1fr 110px;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .row .name {
+      font-size: 12px;
+      font-weight: 700;
+      line-height: 1.2;
+    }
+
+    .row .sub {
+      margin-top: 2px;
+      font-size: 11px;
+      color: var(--muted);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .bar {
+      height: 10px;
+      border-radius: 999px;
+      background: #f3f4f6;
+      overflow: hidden;
+      border: 1px solid #eef2f7;
+    }
+
+    .bar > span {
+      display: block;
+      height: 100%;
+      width: 0;
+      background: var(--accent);
+    }
+
+    .bar.blue > span { background: var(--accent-2); }
+
+    .stack {
+      height: 12px;
+      border-radius: 999px;
+      overflow: hidden;
+      border: 1px solid #eef2f7;
+      background: #f3f4f6;
+      display: grid;
+      grid-template-columns: {{ dist.top_pct|floatformat:0 }}% {{ dist.otros_pct|floatformat:0 }}%;
+    }
+
+    .stack .a { background: var(--accent); }
+    .stack .b { background: #d1d5db; }
+
+    .stack-legend {
+      display: flex;
+      gap: 10px;
+      margin-top: 8px;
+      font-size: 11px;
+      color: var(--muted);
+      align-items: center;
+    }
+
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      display: inline-block;
+    }
+
+    .dot.a { background: var(--accent); }
+    .dot.b { background: #d1d5db; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+
+    thead th {
+      text-align: left;
+      color: var(--muted);
+      font-weight: 800;
+      font-size: 11px;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+      padding: 10px 8px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    tbody td {
+      padding: 10px 8px;
+      border-bottom: 1px solid var(--line);
+      vertical-align: top;
+    }
+
+    .right { text-align: right; }
+    .money { font-variant-numeric: tabular-nums; }
+
+    .empty {
+      padding: 32px 0;
+      text-align: center;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .footer {
+      margin-top: 12px;
+      display: flex;
+      justify-content: space-between;
+      color: var(--muted);
+      font-size: 11px;
+    }
+
+    @page {
+      size: A4;
+      margin: 18mm;
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="header">
+      <div>
+        <div class="brand">
+          <img src="https://raw.githubusercontent.com/Kevin25DC/celupro-assets/refs/heads/main/logo%20de%20prueba%20dos.png" alt="CELUPRO CO Logo" />
+          <div>
+            <h1>Reporte de Ventas por Productos</h1>
+            <div class="meta">
+              Rango: {{ fecha_inicio|date:"d/m/Y" }} – {{ fecha_fin|date:"d/m/Y" }}<br />
+              Total general: <span class="money">$ {{ total_general|floatformat:0|intcomma }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="badge">Generado: {% now "d/m/Y H:i" %}</div>
+    </div>
+
+    {% if rows %}
+      <div class="grid">
+        <!-- Gráfica 1: Top por ingresos -->
+        <div class="card">
+          <div class="card-title">
+            <h2>Top productos (ingresos)</h2>
+            <span class="chip">Top {{ top_revenue|length }}</span>
+          </div>
+          <div class="rows">
+            {% for r in top_revenue %}
+              <div class="row">
+                <div>
+                  <div class="name">{{ r.nombre }}</div>
+                  <div class="sub money">$ {{ r.total|floatformat:0|intcomma }}</div>
+                </div>
+                <div class="bar"><span style="width: {{ r.pct|floatformat:0 }}%"></span></div>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+
+        <!-- Gráfica 2: Top por cantidad -->
+        <div class="card">
+          <div class="card-title">
+            <h2>Top productos (cantidad)</h2>
+            <span class="chip" style="background:#eff6ff; color:#1d4ed8;">Top {{ top_qty|length }}</span>
+          </div>
+          <div class="rows">
+            {% for r in top_qty %}
+              <div class="row">
+                <div>
+                  <div class="name">{{ r.nombre }}</div>
+                  <div class="sub">Unidades: {{ r.cantidad }}</div>
+                </div>
+                <div class="bar blue"><span style="width: {{ r.pct|floatformat:0 }}%"></span></div>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+
+        <!-- Gráfica 3: Distribución top vs otros -->
+        <div class="card" style="grid-column: 1 / span 2;">
+          <div class="card-title">
+            <h2>Distribución de ingresos</h2>
+            <span class="chip">Top {{ dist.top_n }}</span>
+          </div>
+
+          <div class="stack" title="Top {{ dist.top_n }} vs Otros">
+            <div class="a"></div>
+            <div class="b"></div>
+          </div>
+
+          <div class="stack-legend">
+            <span><span class="dot a"></span> Top {{ dist.top_n }}: <span class="money">$ {{ dist.top_total|floatformat:0|intcomma }}</span> ({{ dist.top_pct|floatformat:0 }}%)</span>
+            <span><span class="dot b"></span> Otros: <span class="money">$ {{ dist.otros_total|floatformat:0|intcomma }}</span> ({{ dist.otros_pct|floatformat:0 }}%)</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title">
+          <h2>Detalle por producto</h2>
+          <span class="chip">{{ rows|length }} productos</span>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Producto</th>
+              <th class="right">Cantidad</th>
+              <th class="right">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for r in rows %}
+              <tr>
+                <td>{{ r.nombre }}</td>
+                <td class="right">{{ r.cantidad }}</td>
+                <td class="right money">$ {{ r.total|floatformat:0|intcomma }}</td>
+              </tr>
+            {% endfor %}
+            <tr>
+              <td></td>
+              <td class="right" style="font-weight:800;">TOTAL</td>
+              <td class="right money" style="font-weight:800;">$ {{ total_general|floatformat:0|intcomma }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="footer">
+        <div>Reporte generado automáticamente.</div>
+        <div>CELUPRO CO</div>
+      </div>
+    {% else %}
+      <div class="empty">No hay ventas por productos en el rango seleccionado.</div>
+    {% endif %}
+  </div>
+</body>
+</html>

--- a/templates/reports/reports_productos.html
+++ b/templates/reports/reports_productos.html
@@ -1,0 +1,975 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}Ventas por productos{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
+<style>
+    .ventas-container {
+        display: flex;
+        min-height: 100vh;
+        background-color: #f9fafb;
+    }
+
+    /* Panel Izquierdo - Filtros */
+    .filters-panel {
+        width: 320px;
+        background: white;
+        border-right: 1px solid #e5e7eb;
+        padding: 2rem 1.5rem;
+        overflow-y: auto;
+        position: fixed;
+        height: 100vh;
+        top: 0;
+        left: 0;
+        z-index: 100;
+    }
+
+    .filters-header {
+        margin-bottom: 2rem;
+    }
+
+    .filters-header h1 {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: #111827;
+        margin: 0 0 0.5rem 0;
+    }
+
+    .filters-header p {
+        font-size: 0.875rem;
+        color: #6b7280;
+        margin: 0;
+    }
+
+    .filter-group {
+        margin-bottom: 1.5rem;
+    }
+
+    .filter-label {
+        display: block;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: #374151;
+        margin-bottom: 0.5rem;
+    }
+
+    .filter-input {
+        width: 100%;
+        padding: 0.625rem 0.75rem;
+        border: 1px solid #d1d5db;
+        border-radius: 0.5rem;
+        font-size: 0.875rem;
+        transition: all 0.2s;
+        background: white;
+    }
+
+    .filter-input:focus {
+        outline: none;
+        border-color: #10b981;
+        box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.1);
+    }
+
+    .filter-input::placeholder {
+        color: #9ca3af;
+    }
+
+    .btn-primary {
+        width: 100%;
+        background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+        color: white;
+        border: none;
+        padding: 0.75rem 1rem;
+        border-radius: 0.5rem;
+        font-weight: 500;
+        font-size: 0.875rem;
+        cursor: pointer;
+        transition: all 0.3s;
+        box-shadow: 0 4px 6px rgba(16, 185, 129, 0.2);
+    }
+
+    .btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 12px rgba(16, 185, 129, 0.3);
+    }
+
+    .btn-primary:active {
+        transform: translateY(0);
+    }
+
+    .btn-secondary {
+        width: 100%;
+        background: #f3f4f6;
+        color: #374151;
+        border: none;
+        padding: 0.625rem 1rem;
+        border-radius: 0.5rem;
+        font-weight: 500;
+        font-size: 0.875rem;
+        cursor: pointer;
+        transition: all 0.2s;
+        margin-top: 0.5rem;
+    }
+
+    .btn-secondary:hover {
+        background: #e5e7eb;
+    }
+
+    /* Panel Derecho - Contenido */
+    .content-panel {
+        flex: 1;
+        margin-left: 320px;
+        padding: 2rem;
+    }
+
+    .content-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: 2rem;
+    }
+
+    .content-title h2 {
+        font-size: 1.875rem;
+        font-weight: 700;
+        color: #111827;
+        margin: 0 0 0.5rem 0;
+    }
+
+    .content-title p {
+        font-size: 0.875rem;
+        color: #6b7280;
+        margin: 0;
+    }
+
+    .download-buttons {
+        display: flex;
+        gap: 0.5rem;
+    }
+
+    .btn-download {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.625rem 1rem;
+        border: none;
+        border-radius: 0.5rem;
+        font-weight: 500;
+        font-size: 0.875rem;
+        cursor: pointer;
+        transition: all 0.2s;
+        color: white;
+    }
+
+    .btn-download.excel {
+        background: linear-gradient(135deg, #059669 0%, #047857 100%);
+    }
+
+    .btn-download.pdf {
+        background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+    }
+
+    .btn-download:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
+
+    .btn-download:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        transform: none;
+    }
+
+    /* Tarjetas de estadísticas */
+    .stats-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 1rem;
+        margin-bottom: 2rem;
+    }
+
+    .stat-card {
+        background: white;
+        border-radius: 0.75rem;
+        padding: 1.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        transition: all 0.3s;
+        border: 1px solid #e5e7eb;
+    }
+
+    .stat-card:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+    }
+
+    .stat-card-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.75rem;
+    }
+
+    .stat-card-title {
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: #6b7280;
+        margin: 0;
+    }
+
+    .stat-icon {
+        width: 40px;
+        height: 40px;
+        border-radius: 0.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.25rem;
+    }
+
+    .stat-icon.blue { background: #dbeafe; }
+    .stat-icon.green { background: #d1fae5; }
+    .stat-icon.purple { background: #e9d5ff; }
+    .stat-icon.yellow { background: #fef3c7; }
+
+    .stat-value {
+        font-size: 1.875rem;
+        font-weight: 700;
+        color: #111827;
+        margin: 0;
+    }
+
+    .stat-change {
+        font-size: 0.875rem;
+        font-weight: 500;
+        margin-top: 0.25rem;
+    }
+
+    .stat-change.positive { color: #059669; }
+    .stat-change.negative { color: #dc2626; }
+
+    /* Sección del gráfico */
+    .chart-card {
+        background: white;
+        border-radius: 0.75rem;
+        padding: 1.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        border: 1px solid #e5e7eb;
+    }
+
+    .chart-header {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 1.5rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid #e5e7eb;
+    }
+
+    .chart-header h3 {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: #111827;
+        margin: 0;
+    }
+
+    .info-badge {
+        width: 20px;
+        height: 20px;
+        background: #10b981;
+        color: white;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.75rem;
+        font-weight: 700;
+        cursor: help;
+    }
+
+    .chart-container {
+        position: relative;
+        height: 450px;
+    }
+
+    .chart-legend {
+        display: flex;
+        justify-content: center;
+        gap: 2rem;
+        margin-top: 1.5rem;
+        padding-top: 1rem;
+        border-top: 1px solid #e5e7eb;
+    }
+
+    .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.875rem;
+        color: #374151;
+    }
+
+    .legend-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+    }
+
+    /* Loading y estados */
+    .loading-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(255, 255, 255, 0.95);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        border-radius: 0.75rem;
+        z-index: 10;
+    }
+
+    .loading-overlay.active {
+        display: flex;
+    }
+
+    .spinner {
+        border: 4px solid #f3f4f6;
+        border-top: 4px solid #10b981;
+        border-radius: 50%;
+        width: 48px;
+        height: 48px;
+        animation: spin 0.8s linear infinite;
+    }
+
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
+
+    .empty-state {
+        text-align: center;
+        padding: 4rem 2rem;
+        color: #6b7280;
+    }
+
+    .empty-state-icon {
+        font-size: 4rem;
+        margin-bottom: 1rem;
+        opacity: 0.5;
+    }
+
+    .empty-state h4 {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: #374151;
+        margin: 0 0 0.5rem 0;
+    }
+
+    .empty-state p {
+        font-size: 0.875rem;
+        margin: 0;
+    }
+
+    /* Alertas */
+    .alert {
+        padding: 1rem 1.25rem;
+        border-radius: 0.5rem;
+        margin-bottom: 1.5rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        animation: slideIn 0.3s ease;
+    }
+
+    @keyframes slideIn {
+        from {
+            opacity: 0;
+            transform: translateY(-10px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    .alert-info {
+        background: #dbeafe;
+        border-left: 4px solid #3b82f6;
+        color: #1e40af;
+    }
+
+    .alert-error {
+        background: #fee2e2;
+        border-left: 4px solid #ef4444;
+        color: #991b1b;
+    }
+
+    .alert-success {
+        background: #d1fae5;
+        border-left: 4px solid #10b981;
+        color: #065f46;
+    }
+
+    /* Tabla de datos (opcional) */
+    .data-table {
+        width: 100%;
+        background: white;
+        border-radius: 0.75rem;
+        overflow: hidden;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        margin-top: 2rem;
+    }
+
+    .data-table table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    .data-table thead {
+        background: #f9fafb;
+        border-bottom: 1px solid #e5e7eb;
+    }
+
+    .data-table th {
+        padding: 0.75rem 1rem;
+        text-align: left;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: #6b7280;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .data-table td {
+        padding: 1rem;
+        border-bottom: 1px solid #e5e7eb;
+        font-size: 0.875rem;
+        color: #374151;
+    }
+
+    .data-table tbody tr:hover {
+        background: #f9fafb;
+    }
+
+    /* Responsive */
+    @media (max-width: 1024px) {
+        .filters-panel {
+            transform: translateX(-100%);
+            transition: transform 0.3s;
+        }
+
+        .filters-panel.active {
+            transform: translateX(0);
+        }
+
+        .content-panel {
+            margin-left: 0;
+        }
+
+        .mobile-menu-toggle {
+            display: block;
+            position: fixed;
+            bottom: 1rem;
+            right: 1rem;
+            background: #10b981;
+            color: white;
+            width: 56px;
+            height: 56px;
+            border-radius: 50%;
+            border: none;
+            box-shadow: 0 4px 12px rgba(16, 185, 129, 0.4);
+            cursor: pointer;
+            z-index: 101;
+        }
+    }
+
+    @media (max-width: 640px) {
+        .content-panel {
+            padding: 1rem;
+        }
+
+        .content-header {
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .download-buttons {
+            width: 100%;
+            flex-direction: column;
+        }
+
+        .btn-download {
+            width: 100%;
+            justify-content: center;
+        }
+
+        .stats-grid {
+            grid-template-columns: 1fr;
+        }
+
+        .chart-container {
+            height: 300px;
+        }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<br>
+<br>
+<br>
+<div class="ventas-container">
+    <!-- Panel Izquierdo - Filtros -->
+    <aside class="filters-panel" id="filtersPanel">
+        <br>
+        <br>
+        <br>
+        <div class="filters-header">
+            <h1>🧾 Ventas por Productos</h1>
+            <p>Filtra y consulta tus ventas</p>
+        </div>
+
+        <form id="filterForm">
+            <div class="filter-group">
+                <label class="filter-label" for="periodo">
+                    📅 Período de análisis
+                </label>
+                <input 
+                    type="text" 
+                    id="periodo" 
+                    name="periodo" 
+                    class="filter-input" 
+                    placeholder="Seleccionar fechas..."
+                    readonly
+                >
+            </div>
+
+            <div class="filter-group">
+                <label class="filter-label" for="topN">
+                    🔢 Top productos a mostrar
+                </label>
+                <select id="topN" name="topN" class="filter-input">
+                    <option value="10">Top 10</option>
+                    <option value="15" selected>Top 15</option>
+                    <option value="20">Top 20</option>
+                    <option value="25">Top 25</option>
+                </select>
+            </div>
+
+            <button type="submit" class="btn-primary">
+                Generar Reporte
+            </button>
+
+            <button type="button" class="btn-secondary" onclick="limpiarFiltros()">
+                Limpiar Filtros
+            </button>
+        </form>
+
+        <div style="margin-top: 2rem; padding-top: 2rem; border-top: 1px solid #e5e7eb;">
+            <p style="font-size: 0.75rem; color: #9ca3af; margin: 0;">
+                💡 Tip: Selecciona un período y haz clic en "Generar Reporte" para ver las ventas por producto.
+            </p>
+        </div>
+    </aside>
+
+    <!-- Panel Derecho - Contenido -->
+    <main class="content-panel">
+        <div class="content-header">
+            <div class="content-title">
+                <h2>Reporte de Ventas</h2>
+                <p id="periodoActual">Selecciona un período para comenzar</p>
+            </div>
+            <div class="download-buttons">
+                <button class="btn-download excel" id="btnDownloadExcel" disabled>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
+                    </svg>
+                    Excel
+                </button>
+                <button class="btn-download pdf" id="btnDownloadPDF" disabled>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/>
+                    </svg>
+                    PDF
+                </button>
+            </div>
+        </div>
+
+        <div id="alertContainer"></div>
+
+        <!-- Tarjetas de estadísticas -->
+        <div class="stats-grid" id="statsGrid" style="display: none;">
+            <!-- Se llenará dinámicamente -->
+        </div>
+
+        <!-- Gráfico -->
+        <div class="chart-card">
+            <div class="chart-header">
+                <span style="font-size: 1.5rem;">📊</span>
+                <h3>Top productos por valor vendido</h3>
+                <span class="info-badge" title="Visualiza los productos más vendidos en el período seleccionado">?</span>
+            </div>
+
+            <div class="chart-container">
+                <div class="loading-overlay" id="loadingOverlay">
+                    <div class="spinner"></div>
+                </div>
+
+                <div id="emptyState" class="empty-state">
+                    <div class="empty-state-icon">📦</div>
+                    <h4>No hay datos para mostrar</h4>
+                    <p>Selecciona un período y genera el reporte para visualizar las ventas</p>
+                </div>
+
+                <canvas id="salesChart" style="display: none;"></canvas>
+            </div>
+
+            <div class="chart-legend" id="chartLegend" style="display: none;">
+                <!-- Se llenará dinámicamente -->
+            </div>
+        </div>
+    </main>
+</div>
+
+<!-- Botón móvil para abrir filtros -->
+<button class="mobile-menu-toggle" id="mobileMenuToggle" style="display: none;" onclick="toggleMobileMenu()">
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <line x1="3" y1="12" x2="21" y2="12"></line>
+        <line x1="3" y1="6" x2="21" y2="6"></line>
+        <line x1="3" y1="18" x2="21" y2="18"></line>
+    </svg>
+</button>
+{% endblock %}
+
+{% block extra_scripts %}
+<script type="text/javascript" src="https://cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<script>
+let salesChart = null;
+let currentDates = null;
+
+// Inicializar daterangepicker
+$(function() {
+    $('#periodo').daterangepicker({
+        locale: {
+            format: 'DD/MM/YYYY',
+            separator: ' - ',
+            applyLabel: 'Aplicar',
+            cancelLabel: 'Cancelar',
+            fromLabel: 'Desde',
+            toLabel: 'Hasta',
+            customRangeLabel: 'Personalizado',
+            weekLabel: 'S',
+            daysOfWeek: ['Do', 'Lu', 'Ma', 'Mi', 'Ju', 'Vi', 'Sa'],
+            monthNames: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+                         'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+            firstDay: 1
+        },
+        startDate: moment().startOf('month'),
+        endDate: moment().endOf('month'),
+        ranges: {
+            'Hoy': [moment(), moment()],
+            'Ayer': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
+            'Últimos 7 días': [moment().subtract(6, 'days'), moment()],
+            'Últimos 30 días': [moment().subtract(29, 'days'), moment()],
+            'Este mes': [moment().startOf('month'), moment().endOf('month')],
+            'Mes pasado': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')],
+            'Este año': [moment().startOf('year'), moment().endOf('year')]
+        }
+    });
+});
+
+// Manejar envío del formulario
+document.getElementById('filterForm').addEventListener('submit', function(e) {
+    e.preventDefault();
+    cargarDatosVentas();
+});
+
+function cargarDatosVentas() {
+    const periodoInput = $('#periodo').data('daterangepicker');
+    const fechaInicio = periodoInput.startDate.format('YYYY-MM-DD');
+    const fechaFin = periodoInput.endDate.format('YYYY-MM-DD');
+    const topN = document.getElementById('topN').value;
+
+    currentDates = { inicio: fechaInicio, fin: fechaFin };
+
+    // Actualizar texto del período
+    document.getElementById('periodoActual').textContent = 
+        `Período: ${periodoInput.startDate.format('DD/MM/YYYY')} - ${periodoInput.endDate.format('DD/MM/YYYY')}`;
+
+    // Mostrar loading
+    document.getElementById('loadingOverlay').classList.add('active');
+    document.getElementById('emptyState').style.display = 'none';
+    limpiarAlertas();
+
+    const apiUrl = "{% url 'api_ventas_productos_datos' %}";
+    fetch(`${apiUrl}?fecha_inicio=${fechaInicio}&fecha_fin=${fechaFin}&top=${topN}`)
+        .then(response => {
+            if (!response.ok) throw new Error('Error en la respuesta del servidor');
+            return response.json();
+        })
+        .then(data => {
+            if (data.error) throw new Error(data.error);
+            mostrarDatos(data);
+            habilitarBotonesDescarga();
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            mostrarAlerta('Error al cargar los datos: ' + error.message, 'error');
+            mostrarEstadoVacio();
+        })
+        .finally(() => {
+            document.getElementById('loadingOverlay').classList.remove('active');
+        });
+}
+
+function mostrarDatos(data) {
+    const hasData = (data.labels && data.labels.length > 0);
+    
+    if (!hasData) {
+        mostrarEstadoVacio();
+        return;
+    }
+
+    document.getElementById('emptyState').style.display = 'none';
+    document.getElementById('salesChart').style.display = 'block';
+    document.getElementById('chartLegend').style.display = 'flex';
+
+    // Mostrar estadísticas
+    if (data.totales) {
+        mostrarEstadisticas(data.totales);
+    }
+
+    // Crear/actualizar gráfico
+    const ctx = document.getElementById('salesChart').getContext('2d');
+    if (salesChart) salesChart.destroy();
+
+    salesChart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: data.labels,
+            datasets: data.datasets
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                    padding: 12,
+                    titleColor: '#fff',
+                    bodyColor: '#fff',
+                    borderColor: '#10b981',
+                    borderWidth: 1,
+                    callbacks: {
+                        label: function(context) {
+                            let label = context.dataset.label || '';
+                            if (label) label += ': ';
+                            label += formatearMoneda(context.parsed.y);
+                            return label;
+                        }
+                    }
+                }
+            },
+            scales: {
+                x: {
+                    grid: { display: false },
+                    ticks: {
+                        autoSkip: false,
+                        maxRotation: 45,
+                        minRotation: 0,
+                        font: { size: 11 }
+                    }
+                },
+                y: {
+                    beginAtZero: true,
+                    grid: {
+                        color: '#f3f4f6',
+                        drawBorder: false
+                    },
+                    ticks: {
+                        callback: function(value) {
+                            return '$' + (value / 1000000).toFixed(1) + 'M';
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    actualizarLeyenda(data.datasets);
+}
+
+function mostrarEstadisticas(totales) {
+    const statsGrid = document.getElementById('statsGrid');
+    const cambio = totales.diferencia || 0;
+    const porcentaje = totales.porcentaje_cambio || 0;
+    const esPositivo = cambio >= 0;
+
+    statsGrid.innerHTML = `
+        <div class="stat-card">
+            <div class="stat-card-header">
+                <p class="stat-card-title">Ventas Período Actual</p>
+                <div class="stat-icon blue">💰</div>
+            </div>
+            <p class="stat-value">${formatearMoneda(totales.actual)}</p>
+        </div>
+        <div class="stat-card">
+            <div class="stat-card-header">
+                <p class="stat-card-title">Ventas Período Anterior</p>
+                <div class="stat-icon green">📊</div>
+            </div>
+            <p class="stat-value">${formatearMoneda(totales.anterior || 0)}</p>
+        </div>
+        <div class="stat-card">
+            <div class="stat-card-header">
+                <p class="stat-card-title">Diferencia</p>
+                <div class="stat-icon purple">${esPositivo ? '📈' : '📉'}</div>
+            </div>
+            <p class="stat-value" style="color: ${esPositivo ? '#059669' : '#dc2626'}">
+                ${esPositivo ? '+' : ''}${formatearMoneda(cambio)}
+            </p>
+        </div>
+        <div class="stat-card">
+            <div class="stat-card-header">
+                <p class="stat-card-title">Variación</p>
+                <div class="stat-icon yellow">%</div>
+            </div>
+            <p class="stat-value" style="color: ${esPositivo ? '#059669' : '#dc2626'}">
+                ${esPositivo ? '+' : ''}${porcentaje.toFixed(2)}%
+            </p>
+        </div>
+    `;
+    statsGrid.style.display = 'grid';
+}
+
+function actualizarLeyenda(datasets) {
+    const legend = document.getElementById('chartLegend');
+    legend.innerHTML = datasets.map(dataset => `
+        <div class="legend-item">
+            <span class="legend-dot" style="background-color: ${dataset.borderColor}"></span>
+            <span>${dataset.label}</span>
+        </div>
+    `).join('');
+}
+
+function mostrarEstadoVacio() {
+    document.getElementById('emptyState').style.display = 'block';
+    document.getElementById('salesChart').style.display = 'none';
+    document.getElementById('chartLegend').style.display = 'none';
+    document.getElementById('statsGrid').style.display = 'none';
+}
+
+function formatearMoneda(valor) {
+    return new Intl.NumberFormat('es-CO', {
+        style: 'currency',
+        currency: 'COP',
+        minimumFractionDigits: 0
+    }).format(valor);
+}
+
+function mostrarAlerta(mensaje, tipo = 'info') {
+    const alertContainer = document.getElementById('alertContainer');
+    const iconos = {
+        info: 'ℹ️',
+        error: '❌',
+        success: '✅'
+    };
+
+    const alert = document.createElement('div');
+    alert.className = `alert alert-${tipo}`;
+    alert.innerHTML = `${iconos[tipo]} ${mensaje}`;
+    
+    alertContainer.appendChild(alert);
+
+    setTimeout(() => alert.remove(), 5000);
+}
+
+function limpiarAlertas() {
+    document.getElementById('alertContainer').innerHTML = '';
+}
+
+function habilitarBotonesDescarga() {
+    document.getElementById('btnDownloadExcel').disabled = false;
+    document.getElementById('btnDownloadPDF').disabled = false;
+}
+
+function deshabilitarBotonesDescarga() {
+    document.getElementById('btnDownloadExcel').disabled = true;
+    document.getElementById('btnDownloadPDF').disabled = true;
+}
+
+function limpiarFiltros() {
+    $('#periodo').data('daterangepicker').setStartDate(moment().startOf('month'));
+    $('#periodo').data('daterangepicker').setEndDate(moment().endOf('month'));
+    document.getElementById('topN').value = '15';
+    currentDates = null;
+    deshabilitarBotonesDescarga();
+    mostrarEstadoVacio();
+    limpiarAlertas();
+    document.getElementById('periodoActual').textContent = 'Selecciona un período para comenzar';
+}
+
+// Botones de descarga
+document.getElementById('btnDownloadExcel').addEventListener('click', function() {
+    if (!currentDates) return;
+    descargarReporte('excel');
+});
+
+document.getElementById('btnDownloadPDF').addEventListener('click', function() {
+    if (!currentDates) return;
+    descargarReporte('pdf');
+});
+
+function descargarReporte(formato) {
+    if (!currentDates) {
+        mostrarAlerta('Por favor, genera un reporte primero', 'error');
+        return;
+    }
+
+    const downloadUrl = "{% url 'api_ventas_productos_descargar' %}";
+    const url = `${downloadUrl}?fecha_inicio=${currentDates.inicio}&fecha_fin=${currentDates.fin}&formato=${formato}`;
+    
+    mostrarAlerta(`Descargando reporte en formato ${formato.toUpperCase()}...`, 'success');
+    window.location.href = url;
+}
+
+// Menú móvil
+function toggleMobileMenu() {
+    const panel = document.getElementById('filtersPanel');
+    panel.classList.toggle('active');
+}
+
+// Responsive: mostrar botón móvil en pantallas pequeñas
+function checkResponsive() {
+    const toggle = document.getElementById('mobileMenuToggle');
+    if (window.innerWidth <= 1024) {
+        toggle.style.display = 'block';
+    } else {
+        toggle.style.display = 'none';
+        document.getElementById('filtersPanel').classList.remove('active');
+    }
+}
+
+window.addEventListener('resize', checkResponsive);
+window.addEventListener('load', checkResponsive);
+
+// Cerrar menú móvil al hacer clic fuera
+document.addEventListener('click', function(e) {
+    const panel = document.getElementById('filtersPanel');
+    const toggle = document.getElementById('mobileMenuToggle');
+    
+    if (window.innerWidth <= 1024 && 
+        panel.classList.contains('active') && 
+        !panel.contains(e.target) && 
+        !toggle.contains(e.target)) {
+        panel.classList.remove('active');
+    }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
… HTML

- Se actualizó el archivo menu_reports.html para vincularlo al nuevo informe de ventas de productos.
- Se creó el archivo reporte_pdf_producto_ventas.html para generar informes en PDF de ventas de productos.
- Se desarrolló el archivo reports_productos.html para mostrar las ventas de productos con filtros y gráficos.
- Se implementó JavaScript para gestionar la selección de rangos de fechas y la obtención de datos para los informes de ventas.
- Se añadió un diseño adaptable para una mejor usabilidad en dispositivos móviles.